### PR TITLE
Update oc2slpf-v1.0-wip.md

### DIFF
--- a/oc2slpf-v1.0-wip.md
+++ b/oc2slpf-v1.0-wip.md
@@ -321,6 +321,17 @@ Table 2.1.2-1 lists the TARGETs defined in the OpenC2 Language Specification tha
 | 16 | **ipv6_connection** | IPv6-Connection | A network connection as specified by a five-tuple (IPv6) |
 | 1024 | **slpf** | slpf:Target | Targets defined in the Stateless Packet Filter profile |
 
+The semantics/ requirements as they pertain to common targets:
+* ipv4_connection
+    * If the protocol = ICMP, the five-tuple is: src_addr, dst_addr, icmp_type, icmp_code, protocol  
+      Where the ICMP types and codes are defined in RFC 2780
+    * If the protocol = TCP, UDP or SCTP, the five-tuple is: src_addr, src_port, dst_addr, dst_port, protocol
+    * For any other protocol, the five-tuple is: src_addr, unused, dst_addr, unused, protocol 
+* ipv6_connection
+    * If the protocol = ICMP, the five-tuple is: src_addr, dst_addr, icmp_type, icmp_code, protocol  
+      Where the ICMP types and codes are defined in RFC 4443  
+    * If the protocol = TCP, UDP or SCTP, the five-tuple is: src_addr, src_port, dst_addr, dst_port, protocol
+    * For any other protocol, the five-tuple is: src_addr, unused, dst_addr, unused, protocol
  
 #### 2.1.2.2 SLPF Targets
 The slpf:Target type is defined in this specification and is referenced under the slpf namespace. Implementations that choose to include this type MUST import it in accordance with the procedures defined in section 3.3.3 of Version 1.0 of the [OpenC2-Lang-v1.0](#openc2-lang-v10):

--- a/oc2slpf-v1.0-wip.md
+++ b/oc2slpf-v1.0-wip.md
@@ -35,7 +35,7 @@
 
 #### Abstract:
 
-Open Command and Control (OpenC2) is a concise and extensible language to enable the command and control of cyber defense components, subsystems and/or systems in a manner that is agnostic of the underlying products, technologies, transport mechanisms or other aspects of the implementation.  Stateless packet filtering is a cyber defense mechanism that denies or allows traffic based on static properties of the traffic (such as address, port, protocol etc). This profile defines the Actions, Targets, specifiers and options that are consistent with version 1.0 of the OpenC2 Language Specification ([OpenC2-Lang-v1.0](#openc2-lang-v10)) in the context of stateless packet filtering.
+Open Command and Control (OpenC2) is a concise and extensible language to enable the command and control of cyber defense components, subsystems and/or systems in a manner that is agnostic of the underlying products, technologies, transport mechanisms or other aspects of the implementation.  Stateless packet filtering is a cyber defense mechanism that denies or allows traffic based on static properties of the traffic, such as address, port, protocol, etc. This profile defines the Actions, Targets, Specifiers and Options that are consistent with the version 1.0 of the OpenC2 Language Specification ([OpenC2-Lang-v1.0](#openc2-lang-v10)) in the context of stateless packet filtering (SLPF).
 
 #### Status:
 This document was last revised or approved by the OASIS Open Command and Control (OpenC2) TC on the above date. The level of approval is also listed above. Check the "Latest version" location noted above for possible later revisions of this document. Any other numbered Versions and other technical work produced by the Technical Committee (TC) are listed at https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=openc2#technical.
@@ -85,20 +85,20 @@ The name "OASIS" is a trademark of [OASIS](https://www.oasis-open.org/), the own
 
 _This section is non-normative_
 
-OpenC2 is a suite of specifications that enables command and control of cyber defense systems and components.  OpenC2 typically uses a request-response paradigm where a Command is encoded by an OpenC2 Producer (managing application) and transferred to an OpenC2 Consumer (managed device or virtualized function) using a secure transport protocol, and the Consumer can respond with status and any requested information.  
+OpenC2 is a suite of specifications that enables command and control of cyber defense systems and components.  OpenC2 typically uses a request-response paradigm where a Command is encoded by an OpenC2 Producer (managing application) and transferred to an OpenC2 Consumer (managed device or virtualized function) using a secure transport protocol. In addition, the Consumer can respond back with status and any requested information.  
 
-OpenC2 allows the application producing the commands to discover the set of capabilities supported by the managed devices.  These capabilities permit the managing application to adjust its behavior to take advantage of the features exposed by the managed device.  The capability definitions can be easily extended in a noncentralized manner, allowing standard and non-standard capabilities to be defined with semantic and syntactic rigor.
+OpenC2 allows the application producing the commands to discover the set of capabilities supported by the managed devices. Thus, allowing the managing application to adjust its behavior to take advantage of the features exposed by the managed device. The capability definitions can be easily extended in a noncentralized manner, allowing standard and non-standard capabilities to be defined with semantic and syntactic rigor.
 
 ## 1.1 IPR Policy
 This specification is provided under the [Non-Assertion](https://www.oasis-open.org/policies-guidelines/ipr#Non-Assertion-Mode) Mode of the OASIS IPR Policy, the mode chosen when the Technical Committee was established. For information on whether any patents have been disclosed that may be essential to implementing this specification, and any offers of patent licensing terms, please refer to the Intellectual Property Rights section of the TC's web page (https://www.oasis-open.org/committees/openc2/ipr.php).
 
 ## 1.2 Terminology
 * **Action**: The task or activity to be performed (e.g., 'deny').
-* **Actuator**: The entity that performs the Action (e.g., 'Stateless Packet Filtering').
+* **Actuator**: The entity that performs the Action (e.g., 'Stateless Packet Filter').
 * **Command**: A message defined by an Action-Target pair that is sent from a Producer and received by a Consumer.
 * **Consumer**: A managed device / application that receives Commands.  Note that a single device / application can have both Consumer and Producer capabilities.
 * **Producer**: A manager application that sends Commands.
-* **Response**: A message from a Consumer to a Producer acknowledging a Command or returning the requested resources or status to a previously received request.
+* **Response**: A message from a Consumer to a Producer acknowledging the receipt of a Command, providing the appropriate status and/or returning the requested resources.
 * **Target**: The object of the Action, i.e., the Action is performed on the Target (e.g., IP Address).
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [[BCP 14, RFC2119](#rfc2119)] [[RFC8174](#rfc8174)] when, and only when, they appear in all capitals, as shown here.
@@ -109,10 +109,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 Braden, R., Ed., "Requirements for Internet Hosts - Application and Support", STD 3, RFC 1123, DOI 10.17487/RFC1123, October 1989, <https://www.rfc-editor.org/info/rfc1123>.
 ###### [RFC2119]
 Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, DOI 10.17487/RFC2119, March 1997, <https://www.rfc-editor.org/info/rfc2119>.
-###### [RFC2780]
-Bradner, S. and V. Paxson, "IANA Allocation Guidelines For Values In the Internet Protocol and Related Headers", BCP 37, RFC 2780, DOI 10.17487/RFC2780, March 2000, <https://www.rfc-editor.org/info/rfc2780>.
-###### [RFC4443]
-Conta, A., Deering, S., and M. Gupta, Ed., "Internet Control Message Protocol (ICMPv6) for the Internet Protocol Version 6 (IPv6) Specification", STD 89, RFC 4443, DOI 10.17487/RFC4443, March 2006, <https://www.rfc-editor.org/info/rfc4443>.
 ###### [RFC8174]
 Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174, May 2017, <https://www.rfc-editor.org/info/rfc8174>.
 ###### [RFC8259]
@@ -153,7 +149,7 @@ The following color, font and font style conventions are used in this document:
 
 * Property names are in bold style – **'created_at'**.
 * All examples in this document are expressed in JSON. They are in fixed width font, with straight quotes, black text and a light shaded background, and 4-space indentation. JSON examples in this document are representations of JSON Objects. They should not be interpreted as string literals. The ordering of object keys is insignificant. Whitespace before or after JSON structural characters in the examples are insignificant [[RFC8259](#rfc8259)].
-* Parts of the example may be omitted for conciseness and clarity. These omitted parts are denoted with the ellipses (...).
+* Parts of the example may be omitted for conciseness and clarity. These omitted parts are denoted with ellipses (...).
 
 Example:
 
@@ -179,15 +175,15 @@ In general, there are two types of participants involved in the exchange of Open
 **Figure 1-1. OpenC2 Message Exchange**  
 
 OpenC2 is a suite of specifications for OpenC2 Producers and OpenC2 Consumers to command and execute cyber defense functions.  These specifications include the OpenC2 Language Specification, Actuator Profiles, and Transfer Specifications. The OpenC2 Language Specification and Actuator Profile specifications focus on the language content and meaning at the Producer and Consumer of the Command and Response while the transfer specifications focus on the protocols for their exchange.   
-* The **OpenC2 Language Specification ([OpenC2-Lang-v1.0](#openc2-lang-v10))** provides the semantics for the essential elements of the language, the structure for Commands and Responses, and the schema that defines the proper syntax for the language elements that represents the Command or Response.
-* **OpenC2 Actuator Profiles** specify the subset of the OpenC2 language relevant in the context of specific Actuator functions. Cyber defense components, devices, systems and/or instances may (in fact are likely to) implement multiple Actuator profiles.  Actuator profiles extend the language by defining specifiers that identify the Actuator to the required level of precision. Actuator Profiles may define command arguments and Targets that are relevant and/or unique to those Actuator functions.
+* The **OpenC2 Language Specification ([OpenC2-Lang-v1.0](#openc2-lang-v10))** provides the semantics for the essential elements of the language, the structure for Commands and Responses, and the schema that defines the proper syntax for the language elements that represent the Command or Response.
+* **OpenC2 Actuator Profiles** specify subsets of the OpenC2 language relevant to the context of specific Actuator functions. Cyber defense components, devices, systems and/or instances may (in fact are likely to) implement multiple Actuator profiles.  Actuator profiles extend the language by defining specifiers that identify the Actuator to the required level of precision. Actuator Profiles may define command arguments and Targets that are relevant and/or unique to those Actuator functions.
 * **OpenC2 Transfer Specifications** utilize existing protocols and standards to implement OpenC2 in specific environments. These standards are used for communications and security functions beyond the scope of the language, such as message transfer encoding, authentication, and end-to-end transport of OpenC2 messages.
 
 The [OpenC2-Lang-v1.0](#openc2-lang-v10) defines a language used to compose messages for command and control of cyber defense systems and components.  A message consists of a header and a payload (_defined_ as a message body in the OpenC2 Language Specification Version 1.0 and _specified_ in one or more Actuator profiles). 
 
 The language defines two payload structures:
 
-1. **Command**: An instruction from one system known as the OpenC2 "Producer", to one or more systems, the OpenC2 "Consumer(s)", to act on the content of the Command.
+1. **Command**: An instruction from one system known as the OpenC2 "Producer", to one or more systems known as OpenC2 "Consumer(s)", to act on the content of the Command.
 2. **Response**: Any information sent back to the OpenC2 Producer as a result of the Command.  
 
 OpenC2 implementations integrate the related OpenC2 specifications described above with related industry specifications, protocols, and standards. Figure 1-2 depicts the relationships among OpenC2 specifications, and their relationships to other industry standards and environment-specific implementations of OpenC2. Note that the layering of implementation aspects in the diagram is notional, and not intended to preclude any particular approach to implementing the needed functionality (for example, the use of an application-layer message signature function to provide message source authentication and integrity). 
@@ -207,55 +203,55 @@ OpenC2 is conceptually partitioned into four layers as shown in Table 1-1.
 | Message | Transfer Specifications<br>(OpenC2-over-HTTPS, OpenC2-over-CoAP, …) |
 | Secure Transport | HTTPS, CoAP, MQTT, OpenDXL, ... |
 
-* The **Secure Transport** layer provides a communication path between the Producer and the Consumer.  OpenC2 can be layered over any standard transport protocol.
+* The **Secure Transport** layer provides a communication path between the Producer and the Consumer.  OpenC2 can sufficiently utilise any standard transport protocol.
 * The **Message** layer provides a transport- and content-independent mechanism for conveying requests, responses, and notifications.  A transfer specification maps transport-specific protocol elements to a transport-independent set of message elements consisting of content and associated metadata.  
 * The **Common Content** layer defines the structure of OpenC2 Commands and Responses and a set of common language elements used to construct them.
 * The **Function-specific Content** layer defines the language elements used to support a particular cyber defense function.  An actuator profile defines the implementation conformance requirements for that function.  OpenC2 Producers and Consumers will support one or more profiles.
 
-The components of an OpenC2 Command are an Action (what is to be done), a Target (what is being acted upon), an optional Actuator (what is performing the Command), and Command Arguments, which influence how the Command is to be performed. An Action coupled with a Target is sufficient to describe a complete OpenC2 Command. Though optional, the inclusion of an Actuator and/or Command Arguments provides additional precision to a Command.
+The components of an OpenC2 Command are an Action (what is to be done), a Target (what is being acted upon), an optional Actuator (what is performing the Command), and Command Arguments which influence how the Command is to be performed. An Action coupled with a Target is sufficient to describe a complete OpenC2 Command. Though optional, the inclusion of an Actuator and/or Command Arguments provides additional precision to a Command.
 
 The components of an OpenC2 Response are a numerical status code, an optional status text string, and optional results. The format of the results, if included, depend on the type or Response being transferred. 
 
 ## 1.7 Goal
-The goal of the OpenC2 Language Specification is to provide a language for interoperating between functional elements of cyber defense systems. This language used in conjunction with OpenC2 Actuator Profiles and OpenC2 Transfer Specifications allows for vendor-agnostic cybertime response to attacks.
+The goal of the **OpenC2 Language Specification** is to provide a language for interoperating between functional elements of cyber defense systems. This language used in conjunction with OpenC2 Actuator Profiles and OpenC2 Transfer Specifications allows for vendor-agnostic cybertime response to attacks.
 
 The Integrated Adaptive Cyber Defense (IACD) framework defines a collection of activities, based on the traditional OODA (Observe–Orient–Decide–Act) Loop [IACD]:
 
 * Sensing:  gathering of data regarding system activities
 * Sense Making:  evaluating data using analytics to understand what's happening
 * Decision Making:  determining a course-of-action to respond to system events
-* Acting:  Executing the course-of-action 
+* Acting:  executing the course-of-action 
 
-The goal of OpenC2 is to enable coordinated defense in cyber-relevant time between decoupled blocks that perform cyber defense functions.  OpenC2 focuses on the Acting portion of the IACD framework; the assumption that underlies the design of OpenC2 is that the sensing/analytics have been provisioned and the decision to act has been made. This goal and these assumptions guide the design of OpenC2:
+The goal of **OpenC2** is to enable coordinated defense in cyber-relevant time between decoupled blocks that perform cyber defense functions.  OpenC2 focuses on the Acting portion of the IACD framework; the assumption that underlies the design of OpenC2 is that the sensing/analytics have been provisioned and the decision to act has been made. This goal and these assumptions guide the design of OpenC2:
 
 * **Technology Agnostic:**  The OpenC2 language defines a set of abstract atomic cyber defense Actions in a platform and implementation agnostic manner
-* **Concise:**  An OpenC2 Command is intended to convey only the essential information required to describe the Action required and can be represented in a very compact form for communications-constrained environments
+* **Concise:**  An OpenC2 Command is intended to convey only the essential information required to describe an Action and can be represented in a very compact form for communications-constrained environments
 * **Abstract:**  OpenC2 Commands and Responses are defined abstractly and can be encoded and transferred via multiple schemes as dictated by the needs of different implementation environments
-* **Extensible:**  While OpenC2 defines a core set of Actions and Targets for cyber defense, the language is expected to evolve with cyber defense technologies, and permits extensions to accommodate new cyber defense technologies.
+* **Extensible:**  While OpenC2 defines a core set of Actions and Targets for cyber defense, the language is expected to evolve with cyber defense technologies, and permits extensions to accommodate new cyber defense technologies
 
 ## 1.8 Purpose and Scope
 A ‘Stateless Packet Filter’ (SLPF) is a policy enforcement mechanism that restricts or permits traffic based on static values such as source address, destination address, and/or port numbers.  A Stateless Packet Filter does not consider traffic patterns, connection state, data flows, applications, or payload information.  The scope of this profile is limited to Stateless Packet Filtering herein referred to as SLPF. 
 
-This Actuator profile specifies the set of Actions, Targets, specifiers, and Command Arguments that integrates SLPF functionality with the Open Command and Control (OpenC2) Command set. Through this Command set, cyber security orchestrators may gain visibility into and provide control over the SLPF functionality in a manner that is independent of the instance of the SLPF function. 
+This Actuator profile specifies the set of Actions, Targets, Specifiers, and Command Arguments that integrates SLPF functionality with the Open Command and Control (OpenC2) Command set. Through this Command set, cyber security orchestrators may gain visibility into and provide control over the SLPF functionality in a manner that is independent of the instance of the SLPF function. 
 
-All components, devices and systems that provide SLPF functionality will implement the OpenC2 ACTIONS, TARGETS, SPECIFIERS and ARGS identified as required in this document. Actions that are applicable, but not necessarily required, for SLPF will be identified as optional.
+All components, devices and systems that provide SLPF functionality will implement the OpenC2 ACTIONS, TARGETS, SPECIFIERS and ARGUMENTS (ARGS) identified as required in this document. Actions that are applicable, but not necessarily required, for SLPF will be identified as optional.
 
 The purpose of this document is to:
 
-* Identify the required and optional OpenC2 ACTIONS for Actuators with SLPF functionality.
-* Identify the required and optional TARGET types and associated specifiers for each Action in the SLPF class of Actuators.
+* Identify the required and optional OpenC2 ACTIONS for Actuators with SLPF functionality
+* Identify the required and optional TARGET types for each Action in the SLPF class of Actuators
 * Identify ACTUATOR-SPECIFIERS and ARGUMENTS for each Action/Target pair that are applicable and/or unique to the SLPF class of Actuators
-* Annotate each Action/Target pair with a justification and example, and provide sample OpenC2 Commands to a SLPF with corresponding Responses 
+* Annotate each Action/Target pair with a justification and example, and provide sample OpenC2 Commands to a SLPF with corresponding Responses
 
 This SLPF profile:
 
-* Does not define or implement ACTIONS beyond those defined in Version 1.0 of the [OpenC2-Lang-v1.0](#openc2-lang-v10).
-* Is consistent with version 1.0 of the OpenC2 Language Specification
+* Does not define or implement ACTIONS beyond those defined in Version 1.0 of the [OpenC2-Lang-v1.0](#openc2-lang-v10)
+* Is consistent with Version 1.0 of the OpenC2 Language Specification
 
 Cyber defense systems that are utilizing OpenC2 may require the following components to implement the SLPF profile: 
 
-* OpenC2 Producers: Devices that send Commands, receive Responses, and manage the execution of Commands involving one or more SLPF or other Actuators with SLPF capability. The OpenC2 Producer needs _a priori_ knowledge of which Commands the Actuator can process and execute, therefore must understand the profiles for any device that it intends to command.
-* OpenC2 Consumers: Devices or instances that provide stateless packet filtering functions.  Typically these are Actuators that execute the cyber defense function, but could be orchestrators (i.e., a device or instance that forwards Commands to the Actuator).  
+* OpenC2 Producers: Devices that send Commands, receive Responses, and manage the execution of Commands involving one or more SLPF or other Actuators with SLPF capability. The OpenC2 Producer needs _a priori_ knowledge of which Commands the Actuator can process and execute, therefore must understand the profiles for any device that it intends to command
+* OpenC2 Consumers: Devices or instances that provide stateless packet filtering functions.  Typically these are Actuators that execute the cyber defense function, but could be orchestrators (i.e., a device or instance that forwards Commands to the Actuator)  
 
 Though cyber defense components, devices, systems and/or instances may implement multiple Actuator profiles, a particular OpenC2 message may reference at most a single Actuator profile. The scope of this document is limited to SLPF. 
 
@@ -267,7 +263,7 @@ Section One (this section) provides a non-normative overview of the suite of spe
 
 [Section Three](#3-conformance-statements) (normative) presents definitive criteria for conformance so that cyber security stakeholders can be assured that their products, instances and/or integrations are compatible with OpenC2.  
 
-[Annex A](#-annex-a-sample-commands) (non-normative) provides multiple examples of Commands and associated Responses (JSON serialization) are provided to facilitate development.   
+[Annex A](#-annex-a-sample-commands) (non-normative) provides multiple examples of Commands and associated Responses (JSON serialization) to facilitate development.   
 
 ---
 
@@ -275,23 +271,23 @@ Section One (this section) provides a non-normative overview of the suite of spe
 
 _This section is normative_ 
 
-This section defines the set of ACTIONS, TARGETS, SPECIFIERS, and ARGUMENTS that are meaningful in the context of an SLPF. This section also describes the format of the Response frame's status and results field. This section organized into three major subsections; Command Components, Response Components and Commands. 
+This section defines the set of ACTIONS, TARGETS, SPECIFIERS, and ARGUMENTS that are meaningful in the context of an SLPF. This section also describes the appropriate format for the status and results of a Response frame. This section is organized into three major subsections; Command Components, Response Components and Commands. 
 
 ## 2.1 OpenC2 Command Components 
-The components of an OpenC2 Command include ACTIONS, TARGETS, ACTUATORS and associated ARGS and SPECIFIERS.  Appropriate aggregation of the components will define a Command-body that is meaningful in the context of an SLPF.  
+The components of an OpenC2 Command include ACTIONS, TARGETS, ACTUATORS and associated ARGUMENTS (ARGS) and SPECIFIERS.  Appropriate aggregation of the components will define a Command-body that is meaningful in the context of an SLPF.  
 
 This specification identifies the applicable components of an OpenC2 Command.  The components of an OpenC2 Command include: 
 
-* ACTION:  A subset of the ACTIONs defined in the OpenC2 Language specification that are meaningful in the context of a SLPF. 
-    * This profile SHALL NOT define ACTIONs that are external to Version 1.0 of the [OpenC2 Language Specification](#openc2-lang-v10).
-    * This profile MAY augment the definition of the Actions in the context of a SLPF.
-    * This profile SHALL NOT define ACTIONs in a manner that is inconsistent with version 1.0 of the OpenC2 language specification.
-* TARGET:   A subset of the TARGETs and TARGET-SPECIFIERS defined in Version 1.0 of the OpenC2 Language Specification that are meaningful in the context of SLPF and one TARGET (and its associated specifier) that is defined in this specification. 
-* ARGUMENTS:  A subset of the ARGUMENTS defined in the Language Specification and a set of ARGUMENTS defined in this specification.  
-* ACTUATOR:  A set of specifiers defined in this specification that are meaningful in the context of SLPF. 
+* ACTION:  A subset of the ACTIONs defined in the OpenC2 Language Specification that are meaningful in the context of a SLPF. 
+    * This profile SHALL NOT define ACTIONs that are external to Version 1.0 of the [OpenC2 Language Specification](#openc2-lang-v10)
+    * This profile MAY augment the definition of the Actions in the context of a SLPF
+    * This profile SHALL NOT define ACTIONs in a manner that is inconsistent with version 1.0 of the OpenC2 Language Specification
+* TARGET:   A subset of the TARGETs and TARGET-SPECIFIERS defined in Version 1.0 of the OpenC2 Language Specification that are meaningful in the context of SLPF and one TARGET (and its associated specifier) that is defined in this specification 
+* ARGUMENTS:  A subset of the ARGUMENTS defined in the Language Specification and a set of ARGUMENTS defined in this specification 
+* ACTUATOR:  A set of specifiers defined in this specification that are meaningful in the context of SLPF
 
 ### 2.1.1 Actions
-Table 2.1.1-1 presents the OpenC2 Actions defined in version 1.0 of the Language Specification which are meaningful in the context of an SLPF.  The particular Action/Target pairs that are required or optional are presented in [Section 2.3](#2.3-openc2-commands).  
+Table 2.1.1-1 presents the OpenC2 Actions defined in version 1.0 of the Language Specification which are meaningful in the context of an SLPF.  The particular Action/Target pairs that are required or are optional are presented in [Section 2.3](#2.3-openc2-commands).  
 
 **Table 2.1.1-1.  Actions Applicable to SLPF**
 
@@ -299,17 +295,17 @@ Table 2.1.1-1 presents the OpenC2 Actions defined in version 1.0 of the Language
 
 | ID | Name | Description |
 | :--- | :--- | :--- |
-| 3 | **query** | Initiate a request for information. Used to communicate the supported options and determine the state or settings. |
-| 6 | **deny** | Prevent traffic or access. |
-| 8 | **allow** | Permit traffic or access. |
-| 16 | **update** | Instructs the Actuator to update its configuration by retrieving and processing a configuration file and update.  |
-| 20 | **delete** | Remove an access rule. |
+| 3 | **query** | Initiate a request for information. Used to communicate the supported options and determine the state or settings |
+| 6 | **deny** | Prevent traffic or access |
+| 8 | **allow** | Permit traffic or access |
+| 16 | **update** | Instructs the Actuator to update its configuration by retrieving and processing a configuration file and update  |
+| 20 | **delete** | Remove an access rule |
 
 ** **
 
 ### 2.1.2 Targets
 #### 2.1.2.1 Common Targets
-Table 2.1.2-1 lists the TARGETs defined in the OpenC2 Language specification that are applicable to SLPF.  The particular action/target pairs that are required or optional are presented in [Section 2.3](#2.3-openc2-commands).
+Table 2.1.2-1 lists the TARGETs defined in the OpenC2 Language Specification that are applicable to SLPF.  The particular Action/Target pairs that are required or are optional are presented in [Section 2.3](#2.3-openc2-commands).
 
 **Table 2.1.2-1. Targets Applicable to SLPF**
 
@@ -317,39 +313,28 @@ Table 2.1.2-1 lists the TARGETs defined in the OpenC2 Language specification tha
 
 | ID | Name | Type | Description |
 | :--- | :--- | :--- | :--- |
-| 9 | **features** | Features | A set of items such as Action/Target pairs, profiles versions, options that are supported by the Actuator. The target is used with the query Action to determine an Actuator's capabilities. |
-| 10 | **file** | File | Properties of a file. |
-| 13 | **ipv4_net** | IPv4-Net | The representation of one or more IPv4 addresses expressed using CIDR notation. |
-| 14 | **ipv6_net** | IPv6-Net | The representation of one or more IPv6 addresses expressed using CIDR notation. |
+| 9 | **features** | Features | A set of items such as Action/Target pairs, profiles versions, options that are supported by the Actuator. The target is used with the query Action to determine an Actuator's capabilities |
+| 10 | **file** | File | Properties of a file |
+| 13 | **ipv4_net** | IPv4-Net | The representation of one or more IPv4 addresses expressed using CIDR notation |
+| 14 | **ipv6_net** | IPv6-Net | The representation of one or more IPv6 addresses expressed using CIDR notation |
 | 15 | **ipv4_connection** | IPv4-Connection | A network connection as specified by a five-tuple (IPv4) |
 | 16 | **ipv6_connection** | IPv6-Connection | A network connection as specified by a five-tuple (IPv6) |
-| 1024 | **slpf** | slpf:Target | Targets defined in the Stateless Packet Filter profile. |
+| 1024 | **slpf** | slpf:Target | Targets defined in the Stateless Packet Filter profile |
 
-The semantics/ requirements as they pertain to common targets:
-* ipv4_connection
-    * If the protocol = ICMP, the five-tuple is: src_addr, dst_addr, icmp_type, icmp_code, protocol.  
-      Where the ICMP types and codes are defined in RFC 2780.  
-    * If the protocol = TCP, UDP or SCTP, the five-tuple is: src_addr, src_port, dst_addr, dst_port, protocol.
-    * Any other protocol, then the five-tuple is: src_addr, unused, dst_addr, unused, protocol. 
-* ipv6_connection
-    * If the protocol = ICMP, the five-tuple is: src_addr, dst_addr, icmp_type, icmp_code, protocol.  
-      Where the ICMP types and codes are defined in RFC 4443.  
-    * If the protocol = TCP, UDP or SCTP, the five-tuple is: src_addr, src_port, dst_addr, dst_port, protocol.
-    * Any other protocol, the five-tuple is: src_addr, unused, dst_addr, unused, protocol.   
-
+ 
 #### 2.1.2.2 SLPF Targets
 The slpf:Target type is defined in this specification and is referenced under the slpf namespace. Implementations that choose to include this type MUST import it in accordance with the procedures defined in section 3.3.3 of Version 1.0 of the [OpenC2-Lang-v1.0](#openc2-lang-v10):
 
 1. The unique name of the SLPF schema is `oasis-open.org/openc2/v1.0/ap-slpf`
 2. The namespace identifier (nsid) referring to the SLPF schema is:  `slpf`
-3. The list of types imported from the SLPF schema is: `Target`, `Actuator`, `Args`, and `Results`.
-4. The definitions of and conformance requirements for these types are contained in this document.
+3. The list of types imported from the SLPF schema is: `Target`, `Actuator`, `Args`, and `Results`
+4. The definitions of and conformance requirements for these types are contained in this document
 
 **_Type: Target (Choice)_**
 
 | ID | Name | Type | Description |
 | :--- | :--- | :--- | :--- |
-| 1 | **rule_number** | Rule-ID | Immutable identifier assigned when a rule is created, Identifies a rule to be deleted. |
+| 1 | **rule_number** | Rule-ID | Immutable identifier assigned when a rule is created, Identifies a rule to be deleted |
 
 Implementations that choose to implement the slpf:Target MUST support the **rule_number** Target.
 
@@ -366,9 +351,9 @@ Table 2.1.3.1-1 lists the Command Arguments defined in the [OpenC2-Lang-v1.0](#o
 | ID | Name | Type | # | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | 1 | **start_time** | Date-Time | 0..1 | The specific date/time to initiate the action  |
-| 2 | **stop_time** | Date-Time | 0..1 | The specific date/time to terminate the action |
+| 2 | **stop_time** | Date-Time | 0..1 | The specific date/time to terminate the action|
 | 3 | **duration** | Duration | 0..1 | The length of time for an action to be in effect |
-| 4 | **response_requested** | Response-Type | 0..1 | The type of Response required for the action: `none`, `ack`, `status`, `complete`.  |
+| 4 | **response_requested** | Response-Type | 0..1 | The type of Response required for the action: `none`, `ack`, `status`, `complete`  |
 | 1024 | **slpf** | slpf:Args | 0..1 | Command arguments defined in the Stateless Packet Filter profile |
 
 The semantics/requirements as they relate common arguments are documented in Version 1.0 of the OpenC2 Language Specification:  
@@ -383,17 +368,17 @@ The Command Arguments defined in this document are referenced under the slpf nam
 | ID | Name | Type | # | Description |
 | :--- | :--- | :--- | :--- | :--- |
 | 1 | **drop_process** | Drop-Process | 0..1 | Specifies how to handle denied packets |
-| 2 | **running** | Boolean | 0..1 | Normal operations assumes any change to a device are to be implemented as persistent changes. Setting the running modifier to TRUE results in a change that is not persistent in the event of a reboot or restart.  |
-| 3 | **direction** | Direction | 0..1 | Specifies whether to apply rules to incoming or outgoing traffic.  If omitted, rules are applied to both.   |
-| 4 | **insert_rule** | Rule-ID | 0..1 | Specifies the identifier of the rule within a list, typically used in a top-down rule list. |
+| 2 | **running** | Boolean | 0..1 | Normal operations assume any changes to a device are to be implemented persistently. Setting the running modifier to TRUE results in a change that is not persistent in the event of a reboot or restart  |
+| 3 | **direction** | Direction | 0..1 | Specifies whether to apply rules to incoming or outgoing traffic.  If omitted, rules are applied to both   |
+| 4 | **insert_rule** | Rule-ID | 0..1 | Specifies the identifier of the rule within a list, typically used in a top-down rule list |
 
 **_Type: Drop-Process (Enumerated)_**
 
 | ID | Name | Description |
 | :--- | :--- | :--- |
-| 1 | **none** | Drop the packet and do not send a notification to the source of the packet. |
-| 2 | **reject** | Drop the packet and send an ICMP host unreachable (or equivalent) to the source of the packet. |
-| 3 | **false_ack** | Drop the traffic  and send a false acknowledgement.   |
+| 1 | **none** | Drop the packet and do not send a notification to the source of the packet |
+| 2 | **reject** | Drop the packet and send an ICMP host unreachable (or equivalent) to the source of the packet |
+| 3 | **false_ack** | Drop the traffic  and send a false acknowledgement   |
 
 **_Type: Direction (Enumerated)_**
 
@@ -411,22 +396,22 @@ The Command Arguments defined in this document are referenced under the slpf nam
 The semantics/requirements as they relate to SLPF arguments:  
 
 * insert_rule:
-    * The value MUST be immutable - i.e. the identifier assigned to an access rule at creation must not change over the lifetime of that rule.
+    * The value MUST be immutable - i.e. the identifier assigned to an access rule at creation must not change over the lifetime of that rule
 
-    * The value MUST be unique within the scope of an Openc2 Producer and an Openc2 Consumer- i.e. the value MUST map to exactly one deny <target> or allow <target> for a given instance of an SLPF. 
+    * The value MUST be unique within the scope of an Openc2 Producer and an Openc2 Consumer- i.e. the value MUST map to exactly one deny <target> or allow <target> for a given instance of an SLPF 
 
 * directionality: 
-    * Entities that recieve but do not support directionality MUST NOT reply with 200 OK and SHOULD return a 501 error code. 
-    * If absent, then the Command MUST apply to both. 
+    * Entities that recieve but do not support directionality MUST NOT reply with 200 OK and SHOULD return a 501 error code 
+    * If absent, then the Command MUST apply to both
 * drop_process:  If absent or not explicitly set, then the Actuator MUST NOT send any notification to the source of the packet
-* running:  If absent or not explicitly set, then the value is FALSE and any changes are persistent.  
+* running:  If absent or not explicitly set, then the value is FALSE and any changes are persistent 
 
 ### 2.1.4 Actuator Specifiers
-An ACTUATOR is the entity that provides the functionality and performs the Action. The ACTUATOR executes the ACTION on the TARGET. In the context of this profile, the Actuator is the SLPF and the presence of one or more specifiers further refine which Actuator(s) shall execute the Action.
+An ACTUATOR is the entity that provides the functionality and performs the Action. The ACTUATOR executes the ACTION on the TARGET. In the context of this profile, the Actuator is the SLPF and the presence of one or more Specifiers further refine which Actuator(s) shall execute the Action.
 
-Table 2.1.4-1 lists the specifiers that are applicable to the SPLF Actuator. [Annex C](#annex-c-sample-commands) provides sample Commands with the use of specifiers.
+Table 2.1.4-1 lists the Specifiers that are applicable to the SPLF Actuator. [Annex C](#annex-c-sample-commands) provides sample Commands with the use of Specifiers.
 
-The Actuator specifiers defined in this document are referenced under the slpf namespace.
+The Actuator Specifiers defined in this document are referenced under the slpf namespace.
 
 **Table 2.1.4-1. SLPF Specifiers**
 
@@ -442,10 +427,10 @@ The Actuator specifiers defined in this document are referenced under the slpf n
 ## 2.2 OpenC2 Response Components
 Response messages originate from the ACTUATOR as a result of a Command.
 
-Responses associated with required Actions MUST be implemented. Implementations that include optional ACTIONS MUST implement the RESPONSE associated with the implemented ACTION.  Additional details regarding the Command and associated Response are captured in section [2.3](#2.3-openc2-commands).  Examples will be provided in [Annex A](#-annex-a-sample-commands).
+Responses associated with required Actions MUST be implemented. Implementations that include optional ACTIONS MUST implement the RESPONSE associated with the implemented ACTION.  Additional details regarding the Command and associated Response are captured in Section [2.3](#2.3-openc2-commands).  Examples are provided in [Annex A](#-annex-a-sample-commands).
 
 ### 2.2.1 Common Results
-Table 2.2.1-1 lists the results defined in the OpenC2 Language specification that are applicable to SLPF.
+Table 2.2.1-1 lists the results defined in the OpenC2 Language Specification that are applicable to SLPF.
 
 **Table 2.2.1-1. Results Applicable to SLPF**
 
@@ -461,7 +446,7 @@ Table 2.2.1-1 lists the results defined in the OpenC2 Language specification tha
 | 9 | **rate_limit** | Number | 0..1 | Maximum number of requests per minute supported by design or policy |
 | 1024 | **slpf** | slpf:Results | 0..1 | Response data defined in the Stateless Packet Filtering profile |
 
-Table 2.2.1-2 lists the Status Codes defined in the OpenC2 Language specification that are applicable to SLPF.
+Table 2.2.1-2 lists the Status Codes defined in the OpenC2 Language Specification that are applicable to SLPF.
 
 **Table 2.2.1-2. Status Codes**
 
@@ -469,14 +454,14 @@ Table 2.2.1-2 lists the Status Codes defined in the OpenC2 Language specificatio
 
 | Value | Description |
 | :--- | :--- |
-| 102 | Processing. Command received but action not necessarily complete |
+| 102 | Processing. Command received but action not necessarily complete. |
 | 200 | OK. |
-| 400 | Bad Request. Unable to process Command, parsing error |
+| 400 | Bad Request. Unable to process Command, parsing error. |
 | 500 | Internal Error.  For Response type complete, one of the following MAY apply:<br> * Cannot access file or path<br> * Rule number currently in use<br> * Rule not updated |
 | 501 | Not implemented. For Response type complete, one of the following MAY apply:<br> * Target not supported<br> * Option not supported<br> * Command not supported |
 
 ### 2.2.2 SLPF Results
-The results defined in this document are presented in Table 2.2-2.  The results are referenced under the slpf namespace within the OpenC2-Response type defined in the OpenC2 language specification.
+The results defined in this document are presented in Table 2.2-2.  The results are referenced under the slpf namespace within the OpenC2-Response type defined in the OpenC2 Language Specification.
 
 **Table 2.2-2. SLPF Results**
 
@@ -484,13 +469,13 @@ The results defined in this document are presented in Table 2.2-2.  The results 
 
 | Type Name | Type | Description |
 | :--- | :--- | :--- |
-| **rule_number** | Rule-ID | Rule identifier returned from allow or deny Command. |
+| **rule_number** | Rule-ID | Rule identifier returned from allow or deny Command |
 
 ## 2.3 OpenC2 Commands
 
-An OpenC2 Command consists of an ACTION/TARGET pair and associated SPECIFIERS and ARGUMENTs.  This section enumerates the allowed Commands and presents the associated Responses.  
+An OpenC2 Command consists of an ACTION/TARGET pair and associated SPECIFIERS and ARGUMENTS.  This section enumerates the allowed Commands and presents the associated Responses.  
 
-Table 2.3-1 defines the Commands that are valid in the context of the SLPF profile. An ACTION (the top row in Table 2.3-1) paired with a TARGET (the first column in Table 2.3-1) defines an allowable Command. The subsequent subsections provide the property tables applicable to each OpenC2 Command. 
+Table 2.3-1 defines the Commands that are valid in the context of the SLPF profile. An ACTION (the top row in Table 2.3-1) paired with a TARGET (the first column in Table 2.3-1) defines a valid Command. The subsequent subsections provide the property tables applicable to each OpenC2 Command. 
 
 **Table 2.3-1. Command Matrix**
 
@@ -524,24 +509,24 @@ Table 2.3.1-1 summarizes the Command Arguments that apply to all of the Commands
 
 Upon receipt of an unsupported Command Argument, SLPF Consumers 
 
-* MUST NOT respond with a OK/200. 
-* SHOULD respond with the 501 status code. 
-* SHOULD respond with "Option not supported" in the status text.  
-* MAY respond with the 500 status code.
+* MUST NOT respond with a OK/200
+* SHOULD respond with the 501 status code.
+* SHOULD respond with "Option not supported" in the status text 
+* MAY respond with the 500 status code
 
 OpenC2 Producers that send ‘allow target’ Commands and support the ‘delete slpf:rule_number’ Command:
 
 * MUST support the slpf:rule_number Target type as defined in [Section 2.1.2.2](#2122-slpf-targets)
 * SHOULD populate the Command Arguments field with "response_requested" : "complete”
-* MAY populate the Command Arguments field with the "insert_rule" : <integer> option. 
-* MUST populate the Command Arguments field with "response_requested" : “complete" if the insert_rule argument is populated. 
+* MAY populate the Command Arguments field with the "insert_rule" : <integer> option
+* MUST populate the Command Arguments field with "response_requested" : “complete" if the insert_rule argument is populated 
 
 OpenC2 Consumers that receive and successfully parse ‘allow <target>’ Commands but cannot implement the ‘allow <target>’ :
 
-* MUST NOT respond with a OK/200. 
-* SHOULD respond with the 501 status code.
-* SHOULD respond with ‘Rule not updated’ in the status text.
-* MAY respond with the 500 status code. 
+* MUST NOT respond with a OK/200 
+* SHOULD respond with the 501 status code
+* SHOULD respond with ‘Rule not updated’ in the status text
+* MAY respond with the 500 status code 
 
 OpenC2 Consumers that receive ‘allow <target>’ Commands and support the ‘delete slpf:rule_number’ Command:
 
@@ -557,21 +542,21 @@ OpenC2 Consumers that receive ‘allow target’ Commands and support the ‘ins
     * SHOULD respond with ‘Rule number currently in use’ in the  status text. 
     * MAY respond with the 500 status code. 
 
-The valid Target types, associated specifiers, and options are summarized in sections 2.3.1.1 and 2.3.1.2.  Sample Commands are presented in [Annex A](#-annex-a-sample-commands).  
+The valid Target types, associated Specifiers, and Options are summarized in Sections 2.3.1.1 and 2.3.1.2.  Sample Commands are presented in [Annex A](#-annex-a-sample-commands).  
 
 #### 2.3.1.1 ‘Allow ipv4_connection’
 
 The ‘allow ipv4_connection’ Command is OPTIONAL for Openc2 Producers implementing the SLPF.  
 The ‘allow ipv4_connection’ Command is OPTIONAL for Openc2 Consumers implementing the SLPF.  
 
-The Command permits traffic that is consistent with the specified ipv4_connection.  A valid ‘allow ipv4_connection’ Command has at least one property of the ipv4_connection populated and may have any combination of the five properties populated.  An unpopulated property within the the ipv4_connection Target MUST be treated as an ‘any’.  
+The Command permits traffic that is consistent with the specified ipv4_connection.  A valid ‘allow ipv4_connection’ Command has at least one property of the ipv4_connection populated and may have any combination of the five properties populated.  An unpopulated property within the ipv4_connection Target MUST be treated as an ‘any’.  
 
 Products that receive but do not implement the ‘allow ipv4_connection’ Command:
 
-* MUST NOT respond with a OK/200.  
-* SHOULD respond with the 501 response code. 
-* SHOULD respond with ‘Target type not supported’ in the  status text.
-* MAY respond with the 500 status code.
+* MUST NOT respond with a OK/200  
+* SHOULD respond with the 501 response code 
+* SHOULD respond with ‘Target type not supported’ in the  status text
+* MAY respond with the 500 status code
 
 #### 2.3.1.2 ‘Allow ipv6_connection’
 The ‘allow ipv6_connection’ Command is OPTIONAL for Openc2 Producers implementing the SLPF.  
@@ -581,10 +566,10 @@ The Command permits traffic that is consistent with the specified ipv6_connectio
 
 Products that receive but do not implement the ‘allow ipv6_connection’ Command:
 
-* MUST NOT respond with a OK/200.  
-* SHOULD respond with the 501 response code. 
-* SHOULD respond with ‘Target type not supported’ in the  status text.
-* MAY respond with the 500 status code.
+* MUST NOT respond with a OK/200  
+* SHOULD respond with the 501 response code
+* SHOULD respond with ‘Target type not supported’ in the  status text
+* MAY respond with the 500 status code
 
 #### 2.3.1.3 ‘Allow ipv4_net’
 The ‘allow ipv4_net’ Command is OPTIONAL for Openc2 Producers implementing the SLPF.  
@@ -593,10 +578,10 @@ The ‘allow ipv4_net’ Command is OPTIONAL for Openc2 Consumers implementing t
 The Command permits traffic as specified by the range of IPv4 addresses as expressed by CIDR notation. If the mask is absent (or unspecified) then it MUST be treated as a single IPv4 address (i.e. an address range of one element). The address range specified in the ipv4_net MUST be treated as a source OR destination address.  
 
 Products that receive but do not implement the ‘allow ipv4_net’ Command: 
-* MUST NOT respond with a OK/200. 
-* SHOULD respond with the 501 response code. 
-* SHOULD respond with ‘Target type not supported’ in the status text.
-* MAY respond with the 500 status code.
+* MUST NOT respond with a OK/200 
+* SHOULD respond with the 501 response code
+* SHOULD respond with ‘Target type not supported’ in the status text
+* MAY respond with the 500 status code
 
 #### 2.3.1.4 ‘Allow ipv6_net’  
 The ‘allow ipv6_net’ Command is OPTIONAL for Openc2 Producers implementing the SLPF.  
@@ -605,50 +590,50 @@ The ‘allow ipv6_net’ Command is OPTIONAL for Openc2 Consumers implementing t
 The Command permits traffic as specified by the range of IPv6 addresses as expressed by CIDR notation. If the mask is absent (or unspecified) then it MUST be treated as a single IPv6 address (i.e. an address range of one element). The address range specified in the ipv6_net MUST be treated as a source OR destination address. 
 
 Products that receive but do not implement the ‘allow ipv6_net’ Command:
-* MUST NOT respond with a OK/200. 
+* MUST NOT respond with a OK/200
 * SHOULD respond with the 501 response code 
-* SHOULD respond with ‘Target type not supported’ in the status text.
-* MAY respond with the 500 status code.
+* SHOULD respond with ‘Target type not supported’ in the status text
+* MAY respond with the 500 status code
 
 ### 2.3.2 Deny
-‘Deny’ can be treated as mathematical complement to ‘allow’.  With the exception of the additional ‘drop_process’ actuator-argument, the Targets, specifiers, options and corresponding Responses are identical to the four ‘allow’ Commands.  Table 2.3-2 summarizes the Command arguments that apply to all of the Commands consisting of the ‘deny’ Action and valid Target type.  
+‘Deny’ can be treated as mathematical complement to ‘allow’.  With the exception of the additional ‘drop_process’ actuator-argument, the Targets, Specifiers, Options and corresponding Responses are identical to the four ‘allow’ Commands.  Table 2.3-2 summarizes the Command Arguments that apply to all of the Commands consisting of the ‘deny’ Action and valid Target type.  
 
 Upon receipt of a Command with an ARGUMENT that is not supported by the actuator:  
 
 * MUST NOT respond with OK/200
 * SHOULD respond with the 501 status code 
-* SHOULD respond with ‘Option not supported’ in the status text.  
-* MAY respond with the 500 status code.  
+* SHOULD respond with ‘Option not supported’ in the status text  
+* MAY respond with the 500 status code
 
 OpenC2 Producers that send ‘deny target’ Commands and support the ‘delete slpf:rule_number’ Command:
 
 * MUST support the slpf:rule_number Target type as defined in [Section 2.1.2.2](#2122-slpf-targets) 
 * SHOULD populate the Command Arguments field with ‘"response_requested" : "complete”
-* MAY populate the Command Arguments field with the "insert_rule" : <integer> option. 
-* MUST populate the Command Arguments field with "response_requested" : "complete" if the insert_rule argument is populated. 
+* MAY populate the Command Arguments field with the "insert_rule" : <integer> option
+* MUST populate the Command Arguments field with "response_requested" : "complete" if the insert_rule argument is populated 
 
 OpenC2 Consumers that receive ‘deny <target>’ Commands and support the ‘delete slpf:rule_number’ Command:
 
-* MUST support the slpf:rule_number Target type as defined in section [Section 2.1.2.2](#2122-slpf-targets).
-* MUST return the rule number assigned in the slpf object if the "response_requested" : “complete” argument is populated. 
+* MUST support the slpf:rule_number Target type as defined in section [Section 2.1.2.2](#2122-slpf-targets)
+* MUST return the rule number assigned in the slpf object if the "response_requested" : “complete” argument is populated.
 
-OpenC2 Consumers that receive ‘deny target’ Commands and support the ‘insert_rule’ Command argument:
+OpenC2 Consumers that receive ‘deny target’ Commands and support the ‘insert_rule’ Command Argument:
 
-* MUST assign the rule number provided if the "insert_rule" : <integer> argument is populated. 
+* MUST assign the rule number provided if the "insert_rule" : <integer> argument is populated
 * If the rule number is currently in use, then 
-    * MUST NOT respond with a OK/200. 
+    * MUST NOT respond with a OK/200
     * SHOULD respond with the 501 status code 
-    * SHOULD respond with ‘Rule number currently in use’ in the status text. 
-    * MAY respond with the 500 status code.
+    * SHOULD respond with ‘Rule number currently in use’ in the status text
+    * MAY respond with the 500 status code
 
 ### 2.3.3 Query
-The valid Target type, associated specifiers, and options are summarized in section 2.3.3.1.  Sample Commands are presented in [Annex A](#-annex-a-sample-commands). 
+The valid Target type, associated Specifiers, and Options are summarized in Section 2.3.3.1.  Sample Commands are presented in [Annex A](#-annex-a-sample-commands). 
 
 #### 2.3.3.1 Query features
 The ‘query features’ Command MUST be implemented in accordance with Version 1.0 of the [OpenC2-Lang-v1.0](#openc2-lang-v10). 
 
 ### 2.3.4 Delete
-The slpf:rule_number is the only valid Target type for the delete Action. The associated specifiers, and options are summarized in section 2.3.4.1.  Sample Commands are presented in [Annex A](#-annex-a-sample-commands).  
+The slpf:rule_number is the only valid Target type for the delete Action. The associated Specifiers, and Options are summarized in Section 2.3.4.1.  Sample Commands are presented in [Annex A](#-annex-a-sample-commands).  
 
 
 #### 2.3.4.1 delete slpf:rule_number
@@ -656,60 +641,60 @@ The ‘delete slpf:rule_number’ Command is used to remove a firewall rule rath
 
 OpenC2 Producers that send the ‘delete slpf:rule_number’ Command: 
 
-* MAY populate the Command Arguments field with ‘response_requested" : "complete”.
-* MUST NOT include other Command Arguments.  
-* MUST include exactly one rule_number.  
+* MAY populate the Command Arguments field with ‘response_requested" : "complete”
+* MUST NOT include other Command Arguments 
+* MUST include exactly one rule_number
 
 OpenC2 Consumers that receive the ‘delete slpf:rule_number’ Command:
 
 * but cannot parse or process the ‘delete slpf:rule_number’ Command:
-    * MUST NOT respond with a OK/200. 
-    * SHOULD respond with status code 400.  
+    * MUST NOT respond with a OK/200
+    * SHOULD respond with status code 400  
     * MAY respond with the 500 status code
 * but do not support the slpf:rule_number Target type: 
-    * MUST NOT respond with a OK/200. 
+    * MUST NOT respond with a OK/200 
     * SHOULD respond with the 501 status code
-    * SHOULD respond with ‘target not supported’ in the status text.
+    * SHOULD respond with ‘target not supported’ in the status text
     * MAY respond with the 500 status code
-* MUST respond with response code 200 upon successful parsing of the ‘delete slpf:rule_number’ Command and subsequent removal of the corresponding rule.  
-* upon successful parsing but failure to remove the corresponding rule
+* MUST respond with response code 200 upon successful parsing of the ‘delete slpf:rule_number’ Command and subsequent removal of the corresponding rule 
+* upon successful parsing but failure to remove the corresponding rule:
     * MUST NOT respond with OK/200
     * MUST respond with response code 500  
-    * SHOULD respond with ‘firewall rule not removed or updated’ in the status text.  
+    * SHOULD respond with ‘firewall rule not removed or updated’ in the status text
 
 Refer to Annex C for sample Commands.  
 
 ### 2.3.5 Update
-The ‘file’ Target as defined in Version 1.0 of the Language Specification is the only valid Target type for the update Action. The associated specifiers, and options are summarized in section 2.3.5.1.  Sample Commands are presented in [Annex A](#-annex-a-sample-Commands).  
+The ‘file’ Target as defined in Version 1.0 of the Language Specification is the only valid Target type for the update Action. The associated Specifiers, and Options are summarized in Section 2.3.5.1.  Sample Commands are presented in [Annex A](#-annex-a-sample-Commands).  
 
 #### 2.3.5.1 Update file 
-The ‘update file’ Command is used to replace or update files such as configuration files, rule sets,  etc.  Implementation of the update file Command is OPTIONAL.  OpenC2 Consumers that choose to implement the ‘update file’ Command MUST must include all steps that are required for the update file procedure such as retrieving the file(s), install the file(s), restart/ reboot the device etc.  The end state shall be that the firewall operates with the new file at the conclusion of the ‘update file’ Command.  The atomic steps that take place are implementation specific.  
+The ‘update file’ Command is used to replace or update files such as configuration files, rule sets,  etc.  Implementation of the update file Command is OPTIONAL.  OpenC2 Consumers that choose to implement the ‘update file’ Command MUST include all steps that are required for the update file procedure such as retrieving the file(s), install the file(s), restart/ reboot the device etc.  The end state shall be that the firewall operates with the new file at the conclusion of the ‘update file’ Command.  The atomic steps that take place are implementation specific.  
 
 Table 2.3-2 presents the valid options for the ‘update file’ Command.   OpenC2 Producers and Consumers that choose to implement the ‘update file’ Command MUST NOT include options other than the options identified in Table 2.3-2.  
 
 OpenC2 Producers that send the ‘update file’ Command:
 
 * MAY populate the arguments field with the "response_requested" argument.    “Complete”, “Ack” and “None” are valid Response-type for ‘update file’
-* MUST NOT include other Command Arguments.  
-* MUST populate the name specifier in the Target. 
-* SHOULD populate the path specifier in the Target. 
+* MUST NOT include other Command Arguments
+* MUST populate the name Specifier in the Target 
+* SHOULD populate the path Specifier in the Target
 
 OpenC2 Consumers that receive the ‘update file’ Command:  
 
 * but cannot parse or process the Command 
-    * MUST NOT respond with a OK/200.
-    * SHOULD respond with status code 400.  
+    * MUST NOT respond with a OK/200
+    * SHOULD respond with status code 400  
     * MAY respond with the 500 status code
 * but do not support the ‘update file’ Command  
-    * MUST NOT respond with a OK/200.
+    * MUST NOT respond with a OK/200
     * SHOULD respond with status code 501 
-    * SHOULD respond with ‘Command not supported’ in the status text. 
+    * SHOULD respond with ‘Command not supported’ in the status text
     * MAY respond with status code 500
 * but cannot access the file specified in the file Target 
     * MUST respond with status code 500 
-    * SHOULD respond with ‘cannot access file’ in the status text. 
-* upon successful parsing and initiating the processing of the ‘update file’ Command, OpenC2 Consumers MAY respond with response code 102. 
-* upon completion of all the steps necessary to complete the update and the Actuator commences operations functioning with the new file,  OpenC2 Consumers SHOULD respond with response code 200.     
+    * SHOULD respond with ‘cannot access file’ in the status text 
+* upon successful parsing and initiating the processing of the ‘update file’ Command, OpenC2 Consumers MAY respond with response code 102 
+* upon completion of all the steps necessary to complete the update and the Actuator commences operations functioning with the new file,  OpenC2 Consumers SHOULD respond with response code 200    
 
 Refer to [Annex A](#-annex-a-sample-commands) for sample Commands.  
 
@@ -717,20 +702,20 @@ Refer to [Annex A](#-annex-a-sample-commands) for sample Commands.
 
 # 3 Conformance statements
 _This section is normative_  
-This section identifies the requierments for twenty-two conformance profiles as they pertain to two conformance targets.  The two conformace targets are OpenC2 Producers and OpenC2 Consumers (as defined in section 1.8 of this specification).  
+This section identifies the requirements for twenty-two conformance profiles as they pertain to two conformance targets.  The two conformace targets are OpenC2 Producers and OpenC2 Consumers (as defined in section 1.8 of this specification).  
 
 ## 3.1 Clauses Pertaining to the OpenC2 Producer Conformance Target
 All OpenC2 Producers that are conformant to this specification MUST satisfy Conformance Clause 1 and MAY satisfy one or more of Conformance Clauses 2 through 11. 
 
 ### 3.1.1 Conformance Clause 1: Baseline OpenC2 Producer  
 An OpenC2 Producer satisfies Baseline OpenC2 Producer conformance if:  
-* 3.1.1.1 **MUST** support JSON serialization of OpenC2 Commands that are syntactically valid in accordance with the property tables presented in Section 2.1.   
-* 3.1.1.2 All serializations **MUST** be implemented in a manner such that the serialization validates against and provides a one-to-one mapping to the property tables in section 2.1 of this specification.    
-* 3.1.1.3 **MUST** support the use of a Transfer Specification that is capable of delivering authenticated, ordered, lossless and uniquely identified OpenC2 messages.   
-* 3.1.1.4 **SHOULD** support the use of one or more published OpenC2 Transfer Specifications which identify underlying transport protocols such that an authenticated, ordered, lossless, delivery of uniquely identified OpenC2 messages is provided as referenced in section 1 of this specification.  
-* 3.1.1.5 **MUST** be conformant with Version 1.0 of the OpenC2 Language Specification.  
-* 3.1.1.6 **MUST** implement the 'query features' Command in accordance with the normative text provided in version 1.0 of the OpenC2 Language Specification.   
-* 3.1.1.7  **MUST** implement the ‘response_requested’ Command Argument as a valid option for any Command.  
+* 3.1.1.1 **MUST** support JSON serialization of OpenC2 Commands that are syntactically valid in accordance with the property tables presented in Section 2.1  
+* 3.1.1.2 All serializations **MUST** be implemented in a manner such that the serialization validates against and provides a one-to-one mapping to the property tables in Section 2.1 of this specification   
+* 3.1.1.3 **MUST** support the use of a Transfer Specification that is capable of delivering authenticated, ordered, lossless and uniquely identified OpenC2 messages
+* 3.1.1.4 **SHOULD** support the use of one or more published OpenC2 Transfer Specifications which identify underlying transport protocols such that an authenticated, ordered, lossless, delivery of uniquely identified OpenC2 messages is provided as referenced in Section 1 of this specification
+* 3.1.1.5 **MUST** be conformant with Version 1.0 of the OpenC2 Language Specification 
+* 3.1.1.6 **MUST** implement the 'query features' Command in accordance with the normative text provided in Version 1.0 of the OpenC2 Language Specification  
+* 3.1.1.7  **MUST** implement the ‘response_requested’ Command Argument as a valid option for any Command 
 * 3.1.1.8 **MUST** conform to at least one of the following confromance clauses in this specification: 
    * Conformance Clause 2
    * Conformance Clause 3
@@ -739,74 +724,74 @@ An OpenC2 Producer satisfies Baseline OpenC2 Producer conformance if:
 
 ### 3.1.2 Conformance Clause 2: IP Version 4 Connection Producer
 An OpenC2 Producer satisfies 'IP Version 4 Connection Producer' conformance if:  
-* 3.1.2.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 1 of this specification.   
-* 3.1.2.2 **MUST** implement the 'allow ipv4_connection' Command in accordance with section 2.3.1 of this specification.   
-* 3.1.2.3 **MUST** implement the 'deny ipv4_connection' Command in accordance with section 2.3.2 of this specification.  
+* 3.1.2.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 1 of this specification  
+* 3.1.2.2 **MUST** implement the 'allow ipv4_connection' Command in accordance with Section 2.3.1 of this specification  
+* 3.1.2.3 **MUST** implement the 'deny ipv4_connection' Command in accordance with Section 2.3.2 of this specification 
 
 ### 3.1.3 Conformance Clause 3: IP Version 6 Connection Producer
 An OpenC2 Producer satisfies 'IP Version 6 Connection Producer' conformance if:  
-* 3.1.3.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 1 of this specification.   
-* 3.1.3.2 **MUST** implement the 'allow ipv6_connection' Command in accordance with section 2.3.1 of this specification.   
-* 3.1.3.3 **MUST** implement the 'deny ipv6_connection' Command in accordance with section 2.3.2 of this specification.  
+* 3.1.3.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 1 of this specification   
+* 3.1.3.2 **MUST** implement the 'allow ipv6_connection' Command in accordance with Section 2.3.1 of this specification  
+* 3.1.3.3 **MUST** implement the 'deny ipv6_connection' Command in accordance with Section 2.3.2 of this specification
 
 ### 3.1.4 Conformance Clause 4: IP Version 4 Net Producer
 An OpenC2 Producer satisfies 'IP Version 4 Net Producer' conformance if:  
-* 3.1.4.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 1 of this specification.   
-* 3.1.4.2 **MUST** implement the 'allow ipv4_net' Command in accordance with section 2.3.1 of this specification.   
-* 3.1.4.3 **MUST** implement the 'deny ipv4_net' Command in accordance with section 2.3.2 of this specification.  
+* 3.1.4.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 1 of this specification  
+* 3.1.4.2 **MUST** implement the 'allow ipv4_net' Command in accordance with Section 2.3.1 of this specification   
+* 3.1.4.3 **MUST** implement the 'deny ipv4_net' Command in accordance with Section 2.3.2 of this specification  
 
 ### 3.1.5 Conformance Clause 5: IP Version 6 Net Producer
 An OpenC2 Producer satisfies 'IP Version 6 Net Producer' conformance if:  
-* 3.1.5.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 1 of this specification.   
-* 3.1.5.2 **MUST** implement the 'allow ipv6_net' Command in accordance with section 2.3.1 of this specification.   
-* 3.1.5.3 **MUST** implement the 'deny ipv6_net' Command in accordance with section 2.3.2 of this specification.  
+* 3.1.5.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 1 of this specification  
+* 3.1.5.2 **MUST** implement the 'allow ipv6_net' Command in accordance with Section 2.3.1 of this specification   
+* 3.1.5.3 **MUST** implement the 'deny ipv6_net' Command in accordance with Section 2.3.2 of this specification  
 
 ### 3.1.6 Conformance Clause 6: Update File Producer
 An OpenC2 Producer satisfies 'Update File Producer' conformance if:  
-* 3.1.6.1 **MUST** meet all of the conformance criteria ideintified in Conformance Clause 1 of this specification.  
-* 3.1.6.2 **MUST** implement the 'update file' Command in accordance with section 2.3.5.1 of this specification.  
+* 3.1.6.1 **MUST** meet all of the conformance criteria identified in Conformance Clause 1 of this specification 
+* 3.1.6.2 **MUST** implement the 'update file' Command in accordance with Section 2.3.5.1 of this specification 
 
 ### 3.1.7 Conformance Clause 7: delete rule number Producer
 An OpenC2 Producer satisfies 'delete rule Producer' conformance if:  
-* 3.1.7.1 **MUST** meet all of the conformance criteria ideintified in Conformance Clause 1 of this specification.  
-* 3.1.7.2 **MUST** implement the 'delete slpf:rule_number' in accordance with section 2.3.4.1 of this specification.  
+* 3.1.7.1 **MUST** meet all of the conformance criteria identified in Conformance Clause 1 of this specification 
+* 3.1.7.2 **MUST** implement the 'delete slpf:rule_number' in accordance with Section 2.3.4.1 of this specification  
 
 ### 3.1.8 Conformance Clause 8: Running Producer
 An OpenC2 Producer satisfies 'Running Producer' conformance if:  
-* 3.1.8.1 **MUST** meet all of the conformance criteria ideintified in Conformance Clause 1 of this specification.  
-* 3.1.8.2 **MUST** implement the 'running' Command Argument as a valid option for any Command associated with the 'deny' or 'allow' Actions in accordance with sections 2.3.1 and 2.3.2 of this specificaiton.  
+* 3.1.8.1 **MUST** meet all of the conformance criteria identified in Conformance Clause 1 of this specification
+* 3.1.8.2 **MUST** implement the 'running' Command Argument as a valid option for any Command associated with the 'deny' or 'allow' Actions in accordance with Sections 2.3.1 and 2.3.2 of this specificaiton 
 
 ### 3.1.9 Conformance Clause 9: Direction Producer
 An OpenC2 Producer satisfies 'Direction Producer' conformance if:  
-* 3.1.9.1 **MUST** meet all of the conformance criteria ideintified in Conformance Clause 1 of this specification.  
-* 3.1.9.2 **MUST** implement the 'direction' Command Argument as a valid option for any Command associated with the 'deny' or 'allow' Actions in accordance with sections 2.3.1 and 2.3.2 of this specificaiton.  
+* 3.1.9.1 **MUST** meet all of the conformance criteria identified in Conformance Clause 1 of this specification  
+* 3.1.9.2 **MUST** implement the 'direction' Command Argument as a valid option for any Command associated with the 'deny' or 'allow' Actions in accordance with Sections 2.3.1 and 2.3.2 of this specificaiton 
 
 ### 3.1.10 Conformance Clause 10: drop-process Producer
 An OpenC2 Producer satisfies 'drop-process Producer' conformance if:  
-* 3.1.10.1 **MUST** meet all of the conformance criteria ideintified in Conformance Clause 1 of this specification.  
-* 3.1.10.2 **MUST** implement the 'drop_process' Command Argument as a valid option for any Command associated with the 'deny' Actions in accordance with sections 2.3.1 and 2.3.2 of this specificaiton.  
+* 3.1.10.1 **MUST** meet all of the conformance criteria identified in Conformance Clause 1 of this specification 
+* 3.1.10.2 **MUST** implement the 'drop_process' Command Argument as a valid option for any Command associated with the 'deny' Actions in accordance with sections 2.3.1 and 2.3.2 of this specificaiton  
 
 ### 3.1.11 Conformance Clause 11: Temporal Producer
 An OpenC2 Producer satisfies 'Temporal Producer' conformance if:  
-* 3.1.11.1 **MUST** meet all of the conformance criteria ideintified in Conformance Clause 1 of this specification.  
-* 3.1.11.2 **MUST** implement the 'start_time' Command Argument as a valid option for any Command other than 'query features'.  
-* 3.1.11.3 **MUST** implemnet the 'stop_time' and 'duration' Command Arguments as a valid option for any Command other than 'query features' or 'update file'.  
+* 3.1.11.1 **MUST** meet all of the conformance criteria identified in Conformance Clause 1 of this specification 
+* 3.1.11.2 **MUST** implement the 'start_time' Command Argument as a valid option for any Command other than 'query features'
+* 3.1.11.3 **MUST** implement the 'stop_time' and 'duration' Command Arguments as a valid option for any Command other than 'query features' or 'update file'.  
 
 ## 3.2 Clauses Pertaining to the OpenC2 Consumer Conformance Target
 All OpenC2 Consumers that are conformant to this specification MUST satisfy Conformance Clause 12 and MAY satisfy one or more of Conformance Clauses 13 through 22. 
 
 ### 3.2.1 Conformance Clause 12: Baseline OpenC2 Consumer  
 An OpenC2 Consumer satisfies Baseline OpenC2 Consumer conformance if:  
-* 3.2.1.1 **MUST** support JSON serialization of OpenC2 Commands that are syntactically valid in accordance with the property tables presented in Section 2.1.   
-* 3.2.1.2 All serializations **MUST** be implemented in a manner such that the serialization validates against and provides a one-to-one mapping to the property tables in section 2.1 of this specification.    
-* 3.2.1.3 **MUST** support the use of a Transfer Specification that is capable of delivering authenticated, ordered, lossless and uniquely identified OpenC2 messages.   
-* 3.2.1.4 **SHOULD** support the use of one or more published OpenC2 Transfer Specifications which identify underlying transport protocols such that an authenticated, ordered, lossless, delivery of uniquely identified OpenC2 messages is provided as referenced in section 1 of this specification.  
-* 3.2.1.5 **MUST** be conformant with Version 1.0 of the OpenC2 Language Specification.  
-* 3.2.1.6 **MUST** implement the 'query features' Command in accordance with the normative text provided in version 1.0 of the OpenC2 Language Specification.   
-* 3.2.1.7  **MUST** implement the ‘response_requested’ Command Argument as a valid option for any Command.  
-    * 3.2.1.7.1 All Commands received with a Response argument set to 'none' **MUST** process the Command and **MUST NOT** send a Response. This criteria supercedes all other normative text as it pertains to Responses.   
-    * 3.2.1.7.2 All Commands received without the Response argument (or Response argument not set) **MUST** process the Command and Response in a manner that is consistent with "response_requested":"complete".  
-* 3.2.1.8 **MUST** conform to at least one of the following confromance clauses in this specification: 
+* 3.2.1.1 **MUST** support JSON serialization of OpenC2 Commands that are syntactically valid in accordance with the property tables presented in Section 2.1  
+* 3.2.1.2 All serializations **MUST** be implemented in a manner such that the serialization validates against and provides a one-to-one mapping to the property tables in section 2.1 of this specification    
+* 3.2.1.3 **MUST** support the use of a Transfer Specification that is capable of delivering authenticated, ordered, lossless and uniquely identified OpenC2 messages   
+* 3.2.1.4 **SHOULD** support the use of one or more published OpenC2 Transfer Specifications which identify underlying transport protocols such that an authenticated, ordered, lossless, delivery of uniquely identified OpenC2 messages is provided as referenced in Section 1 of this specification  
+* 3.2.1.5 **MUST** be conformant with Version 1.0 of the OpenC2 Language Specification
+* 3.2.1.6 **MUST** implement the 'query features' Command in accordance with the normative text provided in version 1.0 of the OpenC2 Language Specification
+* 3.2.1.7  **MUST** implement the ‘response_requested’ Command Argument as a valid option for any Command
+    * 3.2.1.7.1 All Commands received with a Response argument set to 'none' **MUST** process the Command and **MUST NOT** send a Response. This criteria supercedes all other normative text as it pertains to Responses 
+    * 3.2.1.7.2 All Commands received without the Response argument (or Response argument not set) **MUST** process the Command and Response in a manner that is consistent with "response_requested":"complete" 
+* 3.2.1.8 **MUST** conform to at least one of the following conformance clauses in this specification: 
     * Conformance Clause 13
     * Conformance Clause 14
     * Conformance Clause 15 
@@ -814,58 +799,58 @@ An OpenC2 Consumer satisfies Baseline OpenC2 Consumer conformance if:
 
 ### 3.2.2 Conformance Clause 13: IP Version 4 Connection Consumer
 An OpenC2 Consumer satisfies 'IP Version 4 Connection Consumer' conformance if:  
-* 3.2.2.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 12 of this specification.   
-* 3.2.2.2 **MUST** implement the 'allow ipv4_connection' Command in accordance with section 2.3.1 of this specification.   
-* 3.2.2.3 **MUST** implement the 'deny ipv4_connection' Command in accordance with section 2.3.2 of this specification.  
+* 3.2.2.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 12 of this specification   
+* 3.2.2.2 **MUST** implement the 'allow ipv4_connection' Command in accordance with Section 2.3.1 of this specification   
+* 3.2.2.3 **MUST** implement the 'deny ipv4_connection' Command in accordance with Section 2.3.2 of this specification  
 
 ### 3.2.3 Conformance Clause 14: IP Version 6 Connection Consumer
 An OpenC2 Consumer satisfies 'IP Version 6 Connection Consumer' conformance if:  
-* 3.2.3.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 12 of this specification.   
-* 3.2.3.2 **MUST** implement the 'allow ipv6_connection' Command in accordance with section 2.3.1 of this specification.   
-* 3.2.3.3 **MUST** implement the 'deny ipv6_connection' Command in accordance with section 2.3.2 of this specification.  
+* 3.2.3.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 12 of this specification  
+* 3.2.3.2 **MUST** implement the 'allow ipv6_connection' Command in accordance with Section 2.3.1 of this specification  
+* 3.2.3.3 **MUST** implement the 'deny ipv6_connection' Command in accordance with Section 2.3.2 of this specification 
 
 ### 3.2.4 Conformance Clause 15: IP Version 4 Net Consumer
 An OpenC2 Consumer satisfies 'IP Version 4 Net Consumer' conformance if:  
-* 3.2.4.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 12 of this specification.   
-* 3.2.4.2 **MUST** implement the 'allow ipv4_net' Command in accordance with section 2.3.1 of this specification.   
-* 3.2.4.3 **MUST** implement the 'deny ipv4_net' Command in accordance with section 2.3.2 of this specification.  
+* 3.2.4.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 12 of this specification   
+* 3.2.4.2 **MUST** implement the 'allow ipv4_net' Command in accordance with Section 2.3.1 of this specification  
+* 3.2.4.3 **MUST** implement the 'deny ipv4_net' Command in accordance with Section 2.3.2 of this specification  
 
 ### 3.2.5 Conformance Clause 16: IP Version 6 Net Consumer
 An OpenC2 Consumer satisfies 'IP Version 6 Net Consumer' conformance if:  
-* 3.2.5.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 12 of this specification.   
-* 3.2.5.2 **MUST** implement the 'allow ipv6_net' Command in accordance with section 2.3.1 of this specification.   
-* 3.2.5.3 **MUST** implement the 'deny ipv6_net' Command in accordance with section 2.3.2 of this specification.  
+* 3.2.5.1 **MUST**  meet all of conformance criteria identified in Conformance Clause 12 of this specification   
+* 3.2.5.2 **MUST** implement the 'allow ipv6_net' Command in accordance with Section 2.3.1 of this specification 
+* 3.2.5.3 **MUST** implement the 'deny ipv6_net' Command in accordance with Section 2.3.2 of this specification  
 
 ### 3.2.6 Conformance Clause 17: Update File Consumer
 An OpenC2 Consumer satisfies 'Update File Consumer' conformance if:  
-* 3.2.6.1 **MUST** meet all of the conformance criteria ideintified in Conformance Clause 12 of this specification.  
-* 3.2.6.2 **MUST** implement the 'update file' Command in accordance with section 2.3.5.1 of this specification.  
+* 3.2.6.1 **MUST** meet all of the conformance criteria identified in Conformance Clause 12 of this specification 
+* 3.2.6.2 **MUST** implement the 'update file' Command in accordance with Section 2.3.5.1 of this specification
 
 ### 3.2.7 Conformance Clause 18: delete rule number Consumer
 An OpenC2 Consumer satisfies 'delete rule Consumer' conformance if:  
-* 3.2.7.1 **MUST** meet all of the conformance criteria ideintified in Conformance Clause 12 of this specification.  
-* 3.2.7.2 **MUST** implement the 'delete slpf:rule_number' in accordance with section 2.3.4.1 of this specification.  
+* 3.2.7.1 **MUST** meet all of the conformance criteria identified in Conformance Clause 12 of this specification  
+* 3.2.7.2 **MUST** implement the 'delete slpf:rule_number' in accordance with Section 2.3.4.1 of this specification 
 
 ### 3.2.8 Conformance Clause 19: Running Consumer
 An OpenC2 Consumer satisfies 'Running Consumer' conformance if:  
-* 3.2.8.1 **MUST** meet all of the conformance criteria ideintified in Conformance Clause 12 of this specification.  
-* 3.2.8.2 **MUST** implement the 'running' Command Argument as a valid option for any Command associated with the 'deny' or 'allow' Actions in accordance with sections 2.3.1 and 2.3.2 of this specificaiton.  
+* 3.2.8.1 **MUST** meet all of the conformance criteria identified in Conformance Clause 12 of this specification  
+* 3.2.8.2 **MUST** implement the 'running' Command Argument as a valid option for any Command associated with the 'deny' or 'allow' Actions in accordance with Sections 2.3.1 and 2.3.2 of this specification 
 
 ### 3.2.9 Conformance Clause 20: Direction Consumer
 An OpenC2 Consumer satisfies 'Direction Consumer' conformance if:  
-* 3.2.9.1 **MUST** meet all of the conformance criteria ideintified in Conformance Clause 12 of this specification.  
-* 3.2.9.2 **MUST** implement the 'direction' Command argument as a valid option for any Command associated with the 'deny' or 'allow' Actions in accordance with sections 2.3.1 and 2.3.2 of this specificaiton.  
+* 3.2.9.1 **MUST** meet all of the conformance criteria ideintified in Conformance Clause 12 of this specification 
+* 3.2.9.2 **MUST** implement the 'direction' Command argument as a valid option for any Command associated with the 'deny' or 'allow' Actions in accordance with Sections 2.3.1 and 2.3.2 of this specification
 
 ### 3.2.10 Conformance Clause 21: drop-process Consumer
 An OpenC2 Consumer satisfies 'drop-process Consumer' conformance if:  
-* 3.2.10.1 **MUST** meet all of the conformance criteria ideintified in Conformance Clause 12 of this specification.  
-* 3.2.10.2 **MUST** implement the 'drop_process' Command Argument as a valid option for any command associated with the 'deny' Action in accordance with sections 2.3.1 and 2.3.2 of this specificaiton.  
+* 3.2.10.1 **MUST** meet all of the conformance criteria ideintified in Conformance Clause 12 of this specification 
+* 3.2.10.2 **MUST** implement the 'drop_process' Command Argument as a valid option for any command associated with the 'deny' Action in accordance with Sections 2.3.1 and 2.3.2 of this specification  
 
 ### 3.2.11 Conformance Clause 22: Temporal Consumer
 An OpenC2 Consumer satisfies 'Temporal Consumer' conformance if:  
 * 3.2.11.1 **MUST** meet all of the conformance criteria ideintified in Conformance Clause 12 of this specification.  
-* 3.2.11.2 **MUST** implement the 'start_time' Command Argument as a valid option for any Command other than 'query features'.  
-* 3.2.11.3 **MUST** implemnet the 'stop_time' and 'duration' Command Arguments as a valid option for any Command other than 'query features' or 'update file'. 
+* 3.2.11.2 **MUST** implement the 'start_time' Command Argument as a valid option for any Command other than 'query features'
+* 3.2.11.3 **MUST** implemnet the 'stop_time' and 'duration' Command Arguments as a valid option for any Command other than 'query features' or 'update file'
 
 ---
 
@@ -873,7 +858,7 @@ An OpenC2 Consumer satisfies 'Temporal Consumer' conformance if:
 
 _This section is non-normative_
 
-This section will summarize and provide examples of OpenC2 Commands as they pertain to SLPF firewalls. The sample Commands will be encoded in verbose JSON, however other encodings are possible provided the Command is validated against the property tables defined in section 2 of this specification.  Examples of corresponding Responses will be provided where appropriate.
+This section will summarize and provide examples of OpenC2 Commands as they pertain to SLPF firewalls. The sample Commands will be encoded in verbose JSON, however other encodings are possible provided the Command is validated against the property tables defined in Section 2 of this specification.  Examples of corresponding Responses are provided where appropriate.
 
 The samples provided in this section are for illustrative purposes only and are not to be interpreted as operational examples for actual systems.
 
@@ -895,7 +880,7 @@ The examples include Integer Date-Time fields; the conversion of Integer values 
 =======
 ## A.1 Deny and Allow
 
-Deny and allow can be treated as mathematical complements of each other. Unless otherwise stated, the example Targets, specifiers, modifiers and corresponding Responses are applicable to both Actions.
+Deny and allow can be treated as mathematical complements of each other. Unless otherwise stated, the example Targets, Specifiers, Arguments and corresponding Responses are applicable to both Actions.
 
 ### A.1.1 Deny a particular connection
 Block a particular connection within the domain and do not send a host unreachable. Note, the "slpf":{"drop_process"} argument does not apply to the allow Action.  
@@ -940,7 +925,7 @@ Block a particular connection within the domain and do not send a host unreachab
 
 
 ### A.1.2  Deny all outbound ftp transfers
-Block all outbound ftp data transfers, send false acknowledgement and request ack. Note that the five-tuple is incomplete. Note that the response_type field was not populated therefore will be ‘complete’. Also note that the Actuator called out was SLPF with no additional specifiers, therefore all endpoints that can execute the Command should. Note, the "slpf":{"drop_process"} argument does not apply to the allow Action.  
+Block all outbound ftp data transfers, send false acknowledgement and request ack. Note that the five-tuple is incomplete. Note that the response_type field was not populated therefore will be ‘complete’. Also note that the Actuator called out was SLPF with no additional Specifiers, therefore all endpoints that can execute the Command should. Note, the "slpf":{"drop_process"} argument does not apply to the allow Action.  
 
 **Command:**
 
@@ -1016,7 +1001,7 @@ Block all inbound traffic from 1.2.3.4 and do not respond. In this case the ipv6
 ```
 
 ### A.1.4 Permit ftp transfers to a particular destination. 
-Permit ftp data transfers to ip address 198.51.100.17 from any source.  (Note that an actual application would also need to allow ftp-data (port 20) in order for transfers to be permitted.)
+Permit ftp data transfers to ip address 198.51.100.17 from any source.  (Note that an actual application would also need to allow ftp-data (port 20) in order for transfers to be permitted).
 
 
 **Command:**
@@ -1053,7 +1038,7 @@ In this case the Actuator returned a rule number associated with the allow.
 ## A.2 Delete Rule
 Used to remove a firewall rule rather than issue an allow or deny to counteract the effect of an existing rule. Implementation of the ‘delete slpf:rule_number’ Command is OPTIONAL.
 
-In this case the rule number assigned in a previous allow will be removed (refer to the final example in section C.1)
+In this case the rule number assigned in a previous allow will be removed (refer to the final example in Section C.1)
 
 **Command:**
 
@@ -1125,7 +1110,7 @@ This Actuator could not access the file
 ```
 
 ## A.4 Query features
-Implementation of query openc2 is required.  The query features Command is intended to enable the openc2 producer to determine the capabilities of the Actuator.  The query features Command can also be used to check the status of the Actuator.
+Implementation of query Openc2 is required.  The query features Command is intended to enable the Openc2 producer to determine the capabilities of the Actuator.  The query features Command can also be used to check the status of the Actuator.
 
 ### A.4.1 No query items set 
 This Command uses query features with no query items to verify that the Actuator is functioning. 


### PR DESCRIPTION
-We need to be consistent in the way we write. For example capitalization vs small letter in specific key words (Specifiers, Options, Arguments, Section, Version, OpenC2 Language Specification).

-Options vs. Command Arguments. They are used interchangeably. This may confuse the reader. In the Abstract we have the same "issue" with the word options. I sugget to change it to arguments.

-"In the context of" a SLPF vs an SLPF vs Stateless Packet Filtering. 
(The reader will get a bit confused because you have to understand that the first refers to "a stateless packet filter", the second "an SLPF" (we define an entity - device - a defence system))

-figure 1.1 needs to be centered.